### PR TITLE
Add postinstall to package.json to run install on app

### DIFF
--- a/templates/svelte/package.json
+++ b/templates/svelte/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "dev": "dotnet watch --project ./server",
-    "start": "dotnet run --project ./server"
+    "start": "dotnet run --project ./server",
+    "postinstall": "cd app && npm install"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Runs `npm install` on app to make sure dependencies are installed. 