### PR TITLE
fix rendering of icons for social links

### DIFF
--- a/templates/svelte/app/src/components/Nav/Footer.svelte
+++ b/templates/svelte/app/src/components/Nav/Footer.svelte
@@ -45,12 +45,10 @@ import { siteNav } from "../../stores";
 
       <span class="inline-flex sm:ml-auto sm:mt-0 mt-4 justify-center sm:justify-start">
         {#each siteNav.social as link}
-        <a  class="text-gray-500"href="{link.url}">
-          <i class="w-8 h-8 mr-2" :class="{link.icon}"></i>
+        <a class="text-gray-500" href="{link.url}">
+          <i class="w-8 h-8 mr-2 {link.icon}"></i>
         </a>
         {/each}
-
-
       </span>
     </div>
   </div>


### PR DESCRIPTION
the content of 'link.icon' should be part of the class attribute