### PR TITLE
Footer links rendering variable mismatch and fork awesome icon fixes

### DIFF
--- a/templates/svelte/app/src/components/Nav/Footer.svelte
+++ b/templates/svelte/app/src/components/Nav/Footer.svelte
@@ -12,7 +12,7 @@ import { siteNav } from "../../stores";
           <nav class="list-none mb-10">
             {#each cat.links as link}
             <li v-for="(link,idx) of item.links">
-              <a class="text-gray-600 hover:text-gray-800" href="{cat.url}">{ cat.name }</a>
+              <a class="text-gray-600 hover:text-gray-800" href="{link.url}">{ link.name }</a>
             </li>
             {/each}
           </nav>
@@ -45,7 +45,7 @@ import { siteNav } from "../../stores";
 
       <span class="inline-flex sm:ml-auto sm:mt-0 mt-4 justify-center sm:justify-start">
         {#each siteNav.social as link}
-        <a  class="text-gray-500"href="{link.url}">
+        <a  class="text-gray-500" href="{link.url}">
           <i class="w-8 h-8 mr-2" :class="{link.icon}"></i>
         </a>
         {/each}

--- a/templates/svelte/server/wwwroot/Content/About.md
+++ b/templates/svelte/server/wwwroot/Content/About.md
@@ -1,6 +1,6 @@
 ---
 title: About This Site
-icon: fa-solid fa-screwdriver-wrench
+icon: fa fa-solid fa-wrench
 ---
 
 ## Lorem Ipsum

--- a/templates/svelte/server/wwwroot/Content/Home/ASPNet.md
+++ b/templates/svelte/server/wwwroot/Content/Home/ASPNet.md
@@ -1,6 +1,6 @@
 ---
 title: ASP.NET Help
-icon: fa-regular fa-star
+icon: fa fa-regular fa-star
 index: 5
 ---
 

--- a/templates/svelte/server/wwwroot/Content/Home/Community.md
+++ b/templates/svelte/server/wwwroot/Content/Home/Community.md
@@ -1,6 +1,6 @@
 ---
 title: Community
-icon: fa-solid fa-users-line
+icon: fa fa-solid fa-users
 index: 4
 ---
 

--- a/templates/svelte/server/wwwroot/Content/Home/Documentation.md
+++ b/templates/svelte/server/wwwroot/Content/Home/Documentation.md
@@ -1,6 +1,6 @@
 ---
 title: Documentation
-icon: fa-solid fa-book
+icon: fa fa-solid fa-book
 index: 1
 ---
 

--- a/templates/svelte/server/wwwroot/Content/Home/Ecosystem.md
+++ b/templates/svelte/server/wwwroot/Content/Home/Ecosystem.md
@@ -1,6 +1,6 @@
 ---
 title: Ecosystem
-icon: fa-brands fa-rebel
+icon: fa fa-brands fa-rebel
 index: 3
 ---
 

--- a/templates/svelte/server/wwwroot/Content/Home/MinimalAPI.md
+++ b/templates/svelte/server/wwwroot/Content/Home/MinimalAPI.md
@@ -1,6 +1,6 @@
 ---
 title: Minimal API
-icon: fa-solid fa-rocket
+icon: fa fa-solid fa-rocket
 index: 6
 ---
 

--- a/templates/svelte/server/wwwroot/Content/Home/Tooling.md
+++ b/templates/svelte/server/wwwroot/Content/Home/Tooling.md
@@ -1,6 +1,6 @@
 ---
 title: Tooling
-icon: fa-solid fa-screwdriver-wrench
+icon: fa fa-solid fa-wrench
 index: 2
 ---
 

--- a/templates/svelte/server/wwwroot/Content/Privacy.md
+++ b/templates/svelte/server/wwwroot/Content/Privacy.md
@@ -1,6 +1,6 @@
 ---
 title: Our Privacy Policy
-icon: fa-solid fa-screwdriver-wrench
+icon: fa fa-solid fa-wrench
 ---
 
 ## Lorem Ipsum

--- a/templates/svelte/server/wwwroot/Content/Terms.md
+++ b/templates/svelte/server/wwwroot/Content/Terms.md
@@ -1,6 +1,6 @@
 ---
 title: Terms and Conditions
-icon: fa-solid fa-screwdriver-wrench
+icon: fa fa-solid fa-wrench
 ---
 
 ## Lorem Ipsum


### PR DESCRIPTION
Pull request fixes:
1. variable mismatch when rendering link for particular category in footer.
2. various icons like `fa-screwdriver-wrench` did not exist in the `fork-awesome` icon set. So I replaced them with wrench. Also icons classes list in particular content items needed to have `fa` class at the start.


